### PR TITLE
Fix: page not found error on client-side routes

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,13 @@
 import express from "express";
 import cors from "cors";
 import { handleDemo } from "./routes/demo";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// __dirname is not available in ES modules, so we have to do this trick
+// @ts-ignore
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export function createServer() {
   const app = express();
@@ -10,12 +17,25 @@ export function createServer() {
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
 
-  // Example API routes
+  // API routes
   app.get("/api/ping", (_req, res) => {
     res.json({ message: "Hello from Express server v2!" });
   });
-
   app.get("/api/demo", handleDemo);
+
+  // Serve static files from the 'dist/spa' directory
+  const spaPath = path.resolve(__dirname, "..", "spa");
+  app.use(express.static(spaPath));
+
+  // Handle all other routes by serving the index.html
+  app.get("*", (req, res) => {
+    // Don't serve files from the static folder as index.html
+    if (req.path.includes(".")) {
+      res.status(404).send("Not found");
+      return;
+    }
+    res.sendFile(path.join(spaPath, "index.html"));
+  });
 
   return app;
 }


### PR DESCRIPTION
This commit fixes a "Page not found" error that occurred when refreshing the page on client-side routes. The issue was caused by the server not being configured to handle client-side routing.

The fix involves modifying the Express server to serve the `index.html` file for all non-API routes. This allows the React Router to take over and handle the routing on the client side.